### PR TITLE
Major improvements to `Resource.property` DSL

### DIFF
--- a/lib/knuverse/knufactor/helpers/resource_class.rb
+++ b/lib/knuverse/knufactor/helpers/resource_class.rb
@@ -3,6 +3,31 @@ module KnuVerse
     module Helpers
       # Simple helper class methods for Resource
       module ResourceClass
+        # Determine a list of names to use to access a resource entity attribute
+        # @param original_name [String,Symbol] the name of the underlying attribute
+        # @param opts [Hash] property options as defined in a {Resource} subclass
+        # @return [Array<Symbol>] the list of names
+        def determine_getter_names(original_name, opts)
+          names = []
+          names << (opts[:type] == :boolean ? "#{original_name}?" : original_name)
+          if opts[:as]
+            Array(opts[:as]).each do |new_name|
+              names << (opts[:type] == :boolean ? "#{new_name}?" : new_name)
+            end
+          end
+          names.map(&:to_sym).uniq
+        end
+
+        # Determine a list of names to use to set a resource entity attribute
+        # @param original_name [String,Symbol] the name of the underlying attribute
+        # @param opts [Hash] property options as defined in a {Resource} subclass
+        # @return [Array<Symbol>] the list of names
+        def determine_setter_names(original_name, opts)
+          names = ["#{original_name}="]
+          names.concat Array(opts[:as]).map { |new_name| "#{new_name}=" } if opts[:as]
+          names.map(&:to_sym).uniq
+        end
+
         # Produce a more human-readable representation of {#i18n_key}
         # @note ActiveRecord ActiveModel::Name compatibility method
         # @return [String]

--- a/lib/knuverse/knufactor/resources/client.rb
+++ b/lib/knuverse/knufactor/resources/client.rb
@@ -3,6 +3,7 @@ module KnuVerse
     module Resources
       # The Knufactor Client resource
       #   rubocop:disable Style/ExtraSpacing
+      #   rubocop:disable Metrics/LineLength
       class Client < Resource
         property :bypass_expiration
         property :bypass_limit
@@ -19,25 +20,37 @@ module KnuVerse
         property :enroll_deadline_remaining_minutes
         property :has_password,           type: :boolean, read_only: true
         property :has_pin,                type: :boolean, read_only: true
-        property :has_verified,           type: :boolean, read_only: true
+        property :has_verified,           type: :boolean, read_only: true,  as: :verified
         property :help_tip,                               read_only: true
-        property :is_disabled,            type: :boolean
-        property :is_gauth,               type: :boolean, read_only: true
-        property :is_tenant_client,       type: :boolean, read_only: true
+        property :is_disabled,            type: :boolean,                   as: :disabled
+        property :is_gauth,               type: :boolean, read_only: true,  as: :gauth
+        property :is_tenant_client,       type: :boolean, read_only: true,  as: :tenant_client
         property :last_verification_date, type: :time,    read_only: true
         property :name,                                   read_only: true
         property :notification,                           read_only: true
         property :password,                               write_only: true
-        property :password_lock,          type: :boolean
+        property :password_lock,          type: :boolean,                   as: :password_locked, validate: true
         property :phone_number_last,                      read_only: true
         property :pin_rev,                                read_only: true
         property :role
         property :role_rationale
         property :row_doubling
         property :state,                                  read_only: true
-        property :verification_lock,      type: :boolean
+        property :verification_lock,      type: :boolean,                   as: :verification_locked, validate: true
         property :verification_speed
         property :verification_speed_floor,               read_only: true
+
+        private
+
+        # Used to validate {#password_lock} on set
+        def validate_password_lock(value)
+          value == false # only `false` is valid
+        end
+
+        # Used to validate {#password_lock} on set
+        def validate_verification_lock(value)
+          value == false # only `false` is valid
+        end
       end
     end
   end


### PR DESCRIPTION
Fixing #2, #3, and #4
Now allows `as:` and `validate:`